### PR TITLE
Add support for blackouts with regex

### DIFF
--- a/plugins/blackout-regex/README.rst
+++ b/plugins/blackout-regex/README.rst
@@ -1,0 +1,63 @@
+alerta-blackout-regex
+=====================
+
+`Alerta <https://alerta.io/>`_ plugin to enhance the blackout management, by 
+matching the alerts against blackouts with PCRE (Perl Compatible Regular 
+Expression) on attributes.
+
+A blackout is considered matched when all its attributes are matched.
+
+Once an alert is identified as matching a blackout, a special label is applied,
+with the format: ``regex_blackout=<blackout id>``, where *blackout id* is the 
+ID of the matched blackout, e.g., 
+``regex_blackout=d8ba1d3b-dbfd-4677-ab00-e7f8469d7ad3``. This way, when the 
+alert is fired again, there's no need to verify the matching again, but simply
+verify whether the blackout referenced is still active.
+
+The plugin will gather the list of Blackouts straight from the database. There's
+no caching involved, every alert notification coming in (before being evaluated
+and correlated) will cause a DB query.
+
+Installation
+------------
+
+This plugin is designed to be installed on the Alerta server; the package is 
+available on PyPI so you can install as:
+
+.. code-block:: bash
+
+    pip install alerta-blackout-regex
+
+Configuration
+-------------
+
+Add ``blackout_regex`` to the list of enabled PLUGINS in ``alertad.conf`` server
+configuration file and set plugin-specific variables either in the server
+configuration file or as environment variables.
+
+.. code-block:: ini
+
+  PLUGINS = ['blackout_regex']
+
+.. note::
+
+    To ensure this plugin won't affect the existing Blackouts you may have in 
+    place, it is recommended to list the `blackout_regex` plugin *after* the 
+    native ``blackout`` plugin in the ``PLUGINS`` configuration option or 
+    environment variable.
+
+.. note::
+
+    Plugin originated from: https://github.com/mirceaulinic/alerta-blackout-regex/
+
+References
+----------
+
+- `Suppressing Alerts using Blackouts 
+  <https://docs.alerta.io/en/latest/gettingstarted/tutorial-5-blackouts.html>`_
+
+License
+-------
+
+Copyright (c) 2020-2022 Mircea Ulinic. Available under the Apache License 2.0.
+Copyright (c) 2023 James Kirsch. Available under the Apache License 2.0.

--- a/plugins/blackout-regex/blackout_regex.py
+++ b/plugins/blackout-regex/blackout_regex.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+"""
+Alerta Blackout Regex
+=====================
+
+Alerta plugin to enhance the blackout system.
+"""
+import re
+import logging
+
+from alerta.app import db
+from alerta.plugins import PluginBase
+
+try:
+    from alerta.plugins import app  # alerta >= 5.0
+except ImportError:
+    from alerta.app import app  # alerta < 5.0
+
+log = logging.getLogger("alerta.plugins.blackout_regex")
+
+
+def parse_tags(tag_list):
+    return {k: v for k, v in (i.split("=", 1) for i in tag_list if "=" in i)}
+
+
+class BlackoutRegex(PluginBase):
+    """
+    Blackout Regex alerta plugin
+    Allow regex blackouts to be applied to alerts.
+    """
+
+    def _fetch_blackouts(self):
+        try:
+            count = db.get_blackouts_count()
+            log.debug("There are %d Blackouts currently open", count)
+            blackouts = db.get_blackouts(page=1, page_size=count)
+            log.debug("Retrieved Blackouts from the DB:")
+            log.debug(blackouts)
+        except Exception:
+            log.debug("Unable to retrieve the Blackouts from the DB", exc_info=True)
+            blackouts = []
+        return blackouts
+
+    def _apply_blackout(self, alert):
+        """
+        The regex blackouts are evaluated in the ``post_receive`` in order to
+        have the alert already correlated, therefore provide us with the real
+        Alert ID (after being correlated, and not just a random fresh ID), the
+        tags from the previous evaluation, as well as a pre-filtering by the
+        native blackout mechanisms (i.e., if there's a blackout matching the
+        alert it won't get to this point - if it gets here we therefore evaluate
+        the alert and we're sure it didn't match the literal blackout attributes
+        which is ideal to preserve backwards compatibility).
+        """
+        if not alert:
+            # It actually does happen sometimes that the Alert can be None (and
+            # perhaps something else too?) - for whatever reason.
+            return alert
+
+        if alert.status == "closed" or alert.status == "expired" or alert.status == "shelved":
+            log.debug(f"Alert {alert.id} status is {alert.status}: ignoring")
+            return alert
+
+        blackouts = self._fetch_blackouts()
+
+        alert_tags = parse_tags(alert.tags)
+
+        # When an alert matches a blackout, this plugin adds a special tag
+        # ``regex_blackout`` that points to the blackout ID matched.
+        # This facilitates the blackout matching, by simply checking if the
+        # blackout is still open.
+        if "regex_blackout" in alert_tags:
+            log.debug(
+                "Checking blackout %s which used to match this alert",
+                alert_tags["regex_blackout"],
+            )
+            for blackout in blackouts:
+                if blackout.id == alert_tags["regex_blackout"]:
+                    if blackout.status == "active":
+                        log.debug(
+                            "Blackout %s is still active, setting alert %s "
+                            "status as blackout",
+                            blackout.id,
+                            alert.id,
+                        )
+                        if alert.status != "blackout":
+                            alert.status = "blackout"
+                        return alert
+            # If the blackout is no longer active, simply return
+            # the alert as-is, without changing the status, but
+            # removing the regex_blackout tag, so when the alert is
+            # fired again, we'll know that it does no longer match
+            # an active blackout.
+            log.debug(
+                "Blackout %s does no longer exist, or is not active, removing "
+                "tag and leaving status unchanged",
+                alert_tags["regex_blackout"],
+            )
+            alert.tags = [tag for tag in alert.tags if "regex_blackout=" not in tag]
+            return alert
+
+        # No previous regex blackout match, let's evaluate.
+        # The idea is that if a blackout has a number of attributes configured,
+        # in order to match, the alert must match all of these attributes.
+        for blackout in blackouts:
+            # The general assumption is that a blackout has at least one of
+            # these attributes set, therefore once we try to match only when an
+            # attribute is configured, and skip to the next blackout when the
+            # matching fails.
+            log.debug("Evaluating blackout")
+            log.debug(blackout)
+            match = False
+            if blackout.environment:
+                if not re.search(blackout.environment, alert.environment):
+                    log.debug(
+                        "%s doesn't match the blackout environment %s",
+                        alert.environment,
+                        blackout.environment,
+                    )
+                    continue
+                match = True
+                log.debug(
+                    "%s matched %s",
+                    blackout.environment,
+                    alert.environment,
+                )
+            if blackout.group:
+                if not re.search(blackout.group, alert.group):
+                    log.debug(
+                        "%s doesn't match the blackout group %s",
+                        alert.group,
+                        blackout.group,
+                    )
+                    continue
+                match = True
+                log.debug("%s matched %s", blackout.group, alert.group)
+            if blackout.event:
+                if not re.search(blackout.event, alert.event):
+                    log.debug(
+                        "%s doesn't match the blackout event %s",
+                        alert.event,
+                        blackout.event,
+                    )
+                    continue
+                match = True
+                log.debug("%s matched %s", blackout.event, alert.event)
+            if blackout.resource:
+                if not re.search(blackout.resource, alert.resource):
+                    log.debug(
+                        "%s doesn't match the blackout resource %s",
+                        alert.resource,
+                        blackout.resource,
+                    )
+                    continue
+                match = True
+                log.debug("%s matched %s", blackout.resource, alert.resource)
+            if blackout.service and alert.service:
+                if len(blackout.service) != len(alert.service):
+                    continue
+                if not all(
+                    [
+                        re.search(blackout.service[index], alert.service[index])
+                        for index in range(len(alert.service))
+                    ]
+                ):
+                    log.debug(
+                        "%s don't seem to match the blackout service(s) %s",
+                        str(alert.service),
+                        str(blackout.service),
+                    )
+                    continue
+                match = True
+                log.debug("%s matched %s", blackout.service[0], alert.service[0])
+            if blackout.tags and alert.tags:
+                blackout_tags = parse_tags(blackout.tags)
+                if not set(blackout_tags.keys()).issubset(set(alert_tags.keys())):
+                    # The blackout must have at least as many tags as the alert
+                    # in order to match.
+                    continue
+                if not all(
+                    [
+                        re.search(blackout_tags[blackout_tag], alert_tags[blackout_tag])
+                        for blackout_tag in blackout_tags
+                        if blackout_tag in alert_tags
+                    ]
+                ):
+                    log.debug(
+                        "%s don't seem to match the blackout tag(s) %s",
+                        str(alert_tags),
+                        str(blackout_tags),
+                    )
+                    continue
+                match = True
+            if match:
+                log.debug(
+                    "Alert %s seems to match (regex) blackout %s. "
+                    "Adding regex_blackout and status",
+                    alert.id,
+                    blackout.id,
+                )
+                alert.tags.extend(["regex_blackout={}".format(blackout.id)])
+                alert.status = "blackout"
+                return alert
+
+        return alert
+
+    def pre_receive(self, alert):
+        return self._apply_blackout(alert)
+
+    def post_receive(self, alert):
+        return alert
+
+    def status_change(self, alert, status, text):
+        return alert, status, text

--- a/plugins/blackout-regex/blackout_regex.py
+++ b/plugins/blackout-regex/blackout_regex.py
@@ -8,11 +8,9 @@ Alerta plugin to enhance the blackout system.
 import re
 import logging
 
-from alerta.app import db
+from alerta.models.blackout import Blackout
 from alerta.plugins import PluginBase
 from alerta.exceptions import BlackoutPeriod
-
-from alerta.models.blackout import Blackout
 
 try:
     from alerta.plugins import app  # alerta >= 5.0
@@ -33,14 +31,13 @@ class BlackoutRegex(PluginBase):
     """
     def _fetch_blackouts(self):
         try:
-            count = db.get_blackouts_count()
+            # retrieve all blackouts from the DB.
+            # use the alerta blackout model to retrieve the blackouts.
+            # The model standardizes the data returned from mongodb and postgres db.
+            count = Blackout.count()
             log.debug(f"There are {count} Blackouts currently open")
-            # retrieve all blackouts from the DB
-            blackouts = db.get_blackouts(page=1, page_size=count)
-            # blackouts_dict = db.get_blackouts(page=1, page_size=count)
+            blackouts = Blackout.find_all(page=1, page_size=count)
             log.debug("Retrieved Blackouts from the DB:")
-            # convert the dict to a list of Blackout objects
-            # blackouts = [Blackout(**blackout) for blackout in blackouts_dict]
         except Exception:
             log.error("Unable to retrieve the Blackouts from the DB", exc_info=True)
             blackouts = []
@@ -80,7 +77,6 @@ class BlackoutRegex(PluginBase):
             log.debug(f"Checking blackout {alert_tags['regex_blackout']} which used to match this alert")
             for blackout in blackouts:
                 if blackout.id == alert_tags["regex_blackout"]:
-                    print(blackout)
                     if blackout.status == "active":
                         log.debug(
                             f"Blackout {blackout.id} is still active, setting alert {alert.id} "

--- a/plugins/blackout-regex/blackout_regex.py
+++ b/plugins/blackout-regex/blackout_regex.py
@@ -38,6 +38,7 @@ class BlackoutRegex(PluginBase):
             log.debug(f"There are {count} Blackouts currently open")
             blackouts = Blackout.find_all(page=1, page_size=count)
             log.debug("Retrieved Blackouts from the DB:")
+            log.debug(blackouts)
         except Exception:
             log.error("Unable to retrieve the Blackouts from the DB", exc_info=True)
             blackouts = []

--- a/plugins/blackout-regex/setup.py
+++ b/plugins/blackout-regex/setup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+"""
+import codecs
+from setuptools import setup
+
+__author__ = "Mircea Ulinic <ping@mirceaulinic.net>"
+__author__ = "James Kirsch <headphonejames@gmail.com>"
+
+with codecs.open("README.rst", "r", encoding="utf8") as file:
+    long_description = file.read()
+
+setup(
+    name="alerta-blackout-regex",
+    version="3.1.0",
+    author="Mircea Ulinic, James Kirsch",
+    author_email="headphonejames@gmail.com",
+    py_modules=["blackout_regex"],
+    description="Alerta Blackout enhancement plugin",
+    long_description=long_description,
+    include_package_data=True,
+    zip_safe=True,
+    url='https://github.com/G-Research/alerta-contrib',
+    license="Apache License 2.0",
+    entry_points={"alerta.plugins": ["blackout_regex = blackout_regex:BlackoutRegex"]},
+)

--- a/plugins/blackout-regex/test_blackout_regex.py
+++ b/plugins/blackout-regex/test_blackout_regex.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+import sys
+import logging
+import unittest
+
+from mock import MagicMock
+
+app = sys.modules["alerta.app"] = MagicMock()
+app.db = MagicMock()
+
+BLACKOUTS = [
+    {
+        "status": "active",
+        "environment": "test",
+        "tags": [],
+        "service": [],
+        "resource": r"test\d",
+        "event": None,
+        "group": None,
+        "duration": 3600,
+        "id": "1",
+    },
+    {
+        "status": "active",
+        "environment": "test",
+        "tags": [],
+        "service": ["service-([a-zA-Z])"],
+        "resource": None,
+        "event": None,
+        "group": None,
+        "duration": 3600,
+        "id": "2",
+    },
+    {
+        "status": "active",
+        "environment": "test",
+        "tags": ["site=site.*", "role=router"],
+        "service": [],
+        "resource": None,
+        "event": None,
+        "group": None,
+        "duration": 3600,
+        "id": "3",
+    },
+    {
+        "status": "active",
+        "environment": "test",
+        "tags": ["site=site.*", "role=firewall"],
+        "service": [],
+        "resource": None,
+        "event": None,
+        "group": None,
+        "duration": 3600,
+        "id": "4",
+    },
+    {
+        "status": "closed",
+        "environment": "test",
+        "tags": ["site=site.*", "role=router"],
+        "service": [],
+        "resource": None,
+        "event": None,
+        "group": None,
+        "duration": 3600,
+        "endTime": "1985-03-05T22:45:27.425Z",
+        "id": "5",
+    },
+    {
+        "status": "closed",
+        "environment": r"(rgx|env)",
+        "tags": [],
+        "service": ["test-.*"],
+        "resource": "FPC.*",
+        "event": "FPCDown",
+        "group": None,
+        "duration": 3600,
+        "endTime": "1985-03-05T22:45:27.425Z",
+        "id": "6",
+    },
+    {
+        "status": "active",
+        "environment": r"(rgx|env)",
+        "tags": [],
+        "service": [],
+        "resource": None,
+        "event": None,
+        "group": None,
+        "duration": 3600,
+        "id": "7",
+    },
+]
+
+
+class Model:
+    def __init__(self, **kwargs):
+        for arg, val in kwargs.items():
+            setattr(self, arg, val)
+
+    def __str__(self):
+        return "{name}({attrs})".format(
+            name=self.__class__.__name__,
+            attrs=", ".join(
+                [
+                    "{}={}".format(attr, getattr(self, attr))
+                    for attr in dir(self)
+                    if not attr.startswith("__")
+                ]
+            ),
+        )
+
+
+class Blackout(Model):
+    pass
+
+
+class Alert(Model):
+    def tag(self, tags):
+        self.tags.extend(tags)
+
+    def untag(self, tags):
+        for tag in tags:
+            if tag in self.tags:
+                self.tags.remove(tag)
+
+    def set_status(self, status):
+        self.status = status
+
+
+def _get_blackouts(**kwargs):
+    return [Blackout(**blackout) for blackout in BLACKOUTS]
+
+
+app.db.get_blackouts = _get_blackouts
+
+plugins_mod = sys.modules["alerta.plugins"] = MagicMock()
+plugins_mod.PluginBase = MagicMock
+
+
+from blackout_regex import BlackoutRegex  # pylama: ignore=E402
+
+log = logging.getLogger(__name__)
+
+
+class TestEnhance(unittest.TestCase):
+    def test_new_alert_no_match(self):
+        """
+        Test alert not matching a regex blackout.
+        """
+        alert = Alert(
+            id="no-match",
+            environment="test",
+            resource="test::resource",
+            event="test-event",
+            group="test",
+            service=["test-service"],
+            tags=["test-tag"],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "open")
+        self.assertEqual(test.tags, ["test-tag"])
+
+    def test_new_alert_match_environment(self):
+        """
+        Test alert matching a regex blackout on the environment field.
+        """
+        alert = Alert(
+            id="match-env",
+            environment="rgx",
+            resource="test10",
+            event="test-event",
+            group="test",
+            service=["test-service"],
+            tags=[],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "blackout")
+        self.assertEqual(test.tags, ["regex_blackout=7"])
+
+    def test_new_alert_match_resource(self):
+        """
+        Test alert matching a regex blackout on the resource field.
+        """
+        alert = Alert(
+            id="match-resource",
+            environment="test",
+            resource="test1",
+            event="test-event",
+            group="test",
+            service=["test-service"],
+            tags=[],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "blackout")
+        self.assertEqual(test.tags, ["regex_blackout=1"])
+
+    def test_new_alert_match_service(self):
+        """
+        Test alert matching a regex blackout on the service field.
+        """
+        alert = Alert(
+            id="match-service",
+            environment="test",
+            resource="test::resource",
+            event="test-event",
+            group="test",
+            service=["service-blah"],
+            tags=[],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "blackout")
+        self.assertEqual(test.tags, ["regex_blackout=2"])
+
+    def test_new_alert_match_tag(self):
+        """
+        Test alert matching a regex blackout on the tag(s).
+        """
+        alert = Alert(
+            id="match-tag",
+            environment="test",
+            resource="test::resource",
+            event="test-event",
+            group="test",
+            service=["test-service"],
+            tags=["site=siteX", "role=router"],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "blackout")
+        self.assertEqual(test.tags, ["site=siteX", "role=router", "regex_blackout=3"])
+
+    def test_new_alert_no_match_tags(self):
+        """
+        Test alert that doesn't match as not all the tags match.
+        """
+        alert = Alert(
+            id="no-match-tags",
+            environment="test",
+            resource="test::resource",
+            event="test-event",
+            group="test",
+            service=["test-service"],
+            tags=["site=siteX", "role=switch"],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "open")
+        self.assertEqual(test.tags, ["site=siteX", "role=switch"])
+
+    def test_new_alert_multi_match(self):
+        """
+        Test alert matching a regex blackout on multiple attributes.
+        """
+        alert = Alert(
+            id="multi-match",
+            environment="rgx",
+            resource="FPC1",
+            event="FPCDown",
+            group="test",
+            service=["test-service"],
+            tags=["site=siteX"],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "blackout")
+        self.assertEqual(test.tags, ["site=siteX", "regex_blackout=6"])
+
+    def test_old_alert_inactive_blackout(self):
+        """
+        Test an existing alert whose associated blackout is currently inactive.
+        """
+        alert = Alert(
+            id="old-alert",
+            environment="test",
+            resource="test::resource",
+            event="test-event",
+            group="test",
+            service=["test-service"],
+            tags=["site=siteX", "regex_blackout=5"],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "open")
+        self.assertEqual(test.tags, ["site=siteX"])
+
+    def test_old_alert_removed_blackout(self):
+        """
+        Test an existing alert whose associated blackout no longer exists.
+        """
+        alert = Alert(
+            id="old-alert",
+            environment="test",
+            resource="test::resource",
+            event="test-event",
+            group="test",
+            service=["test-service"],
+            tags=["site=siteX", "regex_blackout=99"],
+            status="open",
+        )
+        test_obj = BlackoutRegex()
+        test = test_obj.pre_receive(alert)
+        self.assertEqual(test.status, "open")
+        self.assertEqual(test.tags, ["site=siteX"])

--- a/plugins/blackout-regex/test_blackout_regex.py
+++ b/plugins/blackout-regex/test_blackout_regex.py
@@ -127,8 +127,8 @@ class Alert(Model):
 
 
 def _get_blackouts(**kwargs):
-    return [Blackout(**blackout) for blackout in BLACKOUTS]
-
+    return ([Blackout(**blackout) for blackout in BLACKOUTS])
+    # return BLACKOUTS
 
 app.db.get_blackouts = _get_blackouts
 

--- a/plugins/jira/alerta_jira.py
+++ b/plugins/jira/alerta_jira.py
@@ -30,7 +30,6 @@ class JiraCreate(PluginBase):
     _jira_finished_transition_str = "Done"
 
     def __init__(self):
-        print(app.config)
         self.jira_config = JIRA_CONFIG
         self._validate_config_params(self.jira_config)
         super().__init__()

--- a/plugins/jira/alerta_jira.py
+++ b/plugins/jira/alerta_jira.py
@@ -44,7 +44,7 @@ class JiraCreate(PluginBase):
 
     def _validate_config_params(self, configParams):
         # validate that required properties are defined
-        required_properties = ["user", "url", "api token", "finished transition"]
+        required_properties = ["user", "url", "api token"]
         for required_property in required_properties:
             if required_property not in configParams:
                 raise RuntimeError(
@@ -141,6 +141,7 @@ class JiraCreate(PluginBase):
         LOG.debug(f"Jira: status change: {alert.id} alert status: {status} text: {text}")
         return alert
 
+    # ununsed for now
     def delete(self, alert: 'Alert', **kwargs) -> bool:
         if alert.attributes and 'jira' in alert.attributes:
             jira_key = alert.attributes["jira"]["key"]


### PR DESCRIPTION
Blackout Regex alerta plugin. Allow regex blackouts to be applied to alerts. Original code from: https://github.com/mirceaulinic/alerta-blackout-regex. Updated and fixed for both postgres and mongodb databases.