### PR TITLE
Fix how blackout_regex handles tags

### DIFF
--- a/plugins/blackout-regex/blackout_regex.py
+++ b/plugins/blackout-regex/blackout_regex.py
@@ -75,7 +75,9 @@ class BlackoutRegex(PluginBase):
         # This facilitates the blackout matching, by simply checking if the
         # blackout is still open.
         if "regex_blackout" in alert_tags:
-            log.debug(f"Checking blackout {alert_tags['regex_blackout']} which used to match this alert")
+            log.debug(
+                f"Checking blackout {alert_tags['regex_blackout']} which used to match this alert"
+            )
             for blackout in blackouts:
                 if blackout.id == alert_tags["regex_blackout"]:
                     if blackout.status == "active":
@@ -116,9 +118,7 @@ class BlackoutRegex(PluginBase):
                     )
                     continue
                 match = True
-                log.debug(
-                    f"{blackout.environment} matched {alert.environment}"
-                )
+                log.debug(f"{blackout.environment} matched {alert.environment}")
             if blackout.group:
                 if not re.search(blackout.group, alert.group):
                     log.debug(
@@ -165,6 +165,9 @@ class BlackoutRegex(PluginBase):
                 if not set(blackout_tags.keys()).issubset(set(alert_tags.keys())):
                     # The blackout must have at least as many tags as the alert
                     # in order to match.
+                    log.debug(
+                        f"keys of blackout_tags '{blackout_tags.keys()}' and alert_tags '{alert_tags.keys()}' do not match"
+                    )
                     continue
                 if not all(
                     [
@@ -174,16 +177,20 @@ class BlackoutRegex(PluginBase):
                     ]
                 ):
                     log.debug(
-                        "%s don't seem to match the blackout tag(s) %s",
-                        str(alert_tags),
-                        str(blackout_tags),
+                        f"alert tags '{alert_tags}' don't seem to match the blackout tag(s) '{blackout_tags}'"
                     )
                     continue
                 match = True
+            else:
+                log.debug(
+                    f"either blackout.tags '{blackout.tags}' or alert.tags '{alert.tags}' is empty or None"
+                )
             if match:
                 if not NOTIFICATION_BLACKOUT:
-                    log.debug(f'Suppressed alert during blackout period (id={alert.id})')
-                    raise BlackoutPeriod('Suppressed alert during blackout period')
+                    log.debug(
+                        f"Suppressed alert during blackout period (id={alert.id})"
+                    )
+                    raise BlackoutPeriod("Suppressed alert during blackout period")
 
                 log.debug(
                     f"Alert {alert.id} seems to match (regex) blackout {blackout.id}. "


### PR DESCRIPTION
This fixes how blackout_regex evaluates tags, particularly the case where `blackout.tags` or `alert.tags` is `None` or `[]`. Previously this would cause no evaluation of tag matching to occur, even though tags may not match in this case. The main fix is changing the if clause from if blackout.tags and alert.tags: to `if blackout.tags or alert.tags:`. We want tag evaluation to occur if either set of tags is non-empty, not only if they are both non-empty.